### PR TITLE
chore: Update ZeitProvider and CssBaseline case to CamelCase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,14 @@ import ReactDOM from 'react-dom'
 import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
-import { ZEITUIProvider, CSSBaseline } from '@zeit-ui/react'
+import { ZeitProvider, CssBaseline } from '@zeit-ui/react'
 
 ReactDOM.render(
   <React.StrictMode>
-    <ZEITUIProvider>
-      <CSSBaseline />
+    <ZeitProvider>
+      <CssBaseline />
       <App />
-    </ZEITUIProvider>
+    </ZeitProvider>
   </React.StrictMode>,
   document.getElementById('root'),
 )


### PR DESCRIPTION
Fixed incorrect casing on create-react-app Zeit dependency's; unable to start app until updated ZeitProvider and CssBaseline to CamelCase